### PR TITLE
Fix tags to match labels in docs

### DIFF
--- a/composeApp/src/commonMain/kotlin/io/scanbot/barcode/scanner/sdk/example/kmp/doc_code_snippets/custom_ui/GettingStartedCustomUI.kt
+++ b/composeApp/src/commonMain/kotlin/io/scanbot/barcode/scanner/sdk/example/kmp/doc_code_snippets/custom_ui/GettingStartedCustomUI.kt
@@ -205,7 +205,7 @@ fun AdvancedBarcodeScannerConfiguration() {
 
 @Composable
 fun CommonConfigurationExample() {
-    // @Tag("Configuring BarcodeFormatCommonConfiguration")
+    // @Tag("Common configuration")
     val baseConfig = BarcodeFormatCommonConfiguration.default().copy(
         formats = BarcodeFormats.common,
     )
@@ -224,12 +224,12 @@ fun CommonConfigurationExample() {
             // Handle barcodes
         }
     )
-    // @EndTag("Configuring BarcodeFormatCommonConfiguration")
+    // @EndTag("Common configuration")
 }
 
 @Composable
 fun CameraConfigurationExample() {
-    // @Tag("Configuring Camera")
+    // @Tag("Camera configuration")
     val configuration = BarcodeCameraConfiguration(
         detectionEnabled = true,
         flashEnabled = false,
@@ -248,7 +248,7 @@ fun CameraConfigurationExample() {
             // Handle barcodes
         }
     )
-    // @EndTag("Configuring Camera")
+    // @EndTag("Camera configuration")
 }
 
 @Composable
@@ -279,7 +279,7 @@ fun FinderViewConfigurationExample() {
 
 @Composable
 fun SelectionOverlayConfigurationExample() {
-    // @Tag("Configuring Selection Overlay")
+    // @Tag("Selection overlay configuration")
     val overlayConfiguration = SelectionOverlay(
         overlayEnabled = true,
         loadingText = "Scanning...",
@@ -310,12 +310,12 @@ fun SelectionOverlayConfigurationExample() {
             // Handle tap on highlighted barcode
         }
     )
-    // @EndTag("Configuring Selection Overlay")
+    // @EndTag("Selection overlay configuration")
 }
 
 @Composable
 fun CustomBarcodeOverlayExample() {
-    // @Tag("Custom Barcode Overlay")
+    // @Tag("Custom overlay for individual barcodes")
     val overlayConfiguration = SelectionOverlay(
         overlayEnabled = true,
         textFormat = BarcodeOverlayTextFormat.CODE,
@@ -345,7 +345,7 @@ fun CustomBarcodeOverlayExample() {
             // Handle barcodes
         }
     )
-    // @EndTag("Custom Barcode Overlay")
+    // @EndTag("Custom overlay for individual barcodes")
 }
 
 

--- a/composeApp/src/commonMain/kotlin/io/scanbot/barcode/scanner/sdk/example/kmp/doc_code_snippets/scanner/common_use_cases/FindAndPick.kt
+++ b/composeApp/src/commonMain/kotlin/io/scanbot/barcode/scanner/sdk/example/kmp/doc_code_snippets/scanner/common_use_cases/FindAndPick.kt
@@ -5,7 +5,7 @@ package io.scanbot.barcode.scanner.sdk.example.kmp.doc_code_snippets.scanner.com
     This code is not intended for any use outside of the support of documentation by Scanbot SDK GmbH employees.
 */
 
-// @Tag("Find And Pick")
+// @Tag("Find & Pick mode")
 import io.scanbot.sdk.kmp.ScanbotSDK
 import io.scanbot.sdk.kmp.ui_v2.barcode.configuration.BarcodeScannerScreenConfiguration
 import io.scanbot.sdk.kmp.ui_v2.barcode.configuration.BarcodeScannerUiResult
@@ -81,4 +81,4 @@ fun startFindAndPickScanning(
             }
         })
 }
-// @EndTag("Find And Pick")
+// @EndTag("Find & Pick mode")


### PR DESCRIPTION
The labels for the snippets in the docs don't match the tag  names, I have syncronised the names so that they will update correctly in future when the script is used